### PR TITLE
[Trivial] remove omitted replaceVariablesNames in unit test

### DIFF
--- a/tests/loader.js
+++ b/tests/loader.js
@@ -16,16 +16,16 @@ export function loadFile(filepath) {
     throw new Error(`Unsupported filetype ${filepath}`);
 }
 
-export function loadLocale(locale, filepath, replaceVariablesNames = true) {
+export function loadLocale(locale, filepath) {
     if (typeof filepath === 'string') {
-        return addLocale(locale, loadFile(filepath), replaceVariablesNames);
+        return addLocale(locale, loadFile(filepath));
     }
 
     if (
         filepath && typeof filepath === 'object' &&
         filepath.translations && filepath.headers
     ) {
-        return addLocale(locale, filepath, replaceVariablesNames);
+        return addLocale(locale, filepath);
     }
 
     throw new Error(`Unsupported filetype ${filepath}`);

--- a/tests/test_loader.js
+++ b/tests/test_loader.js
@@ -8,8 +8,8 @@ describe('loader', () => {
         const spy = sinon.spy();
         const expected = JSON.parse(fs.readFileSync('tests/fixtures/test-loader.json'));
         rew.__Rewire__('addLocale', spy);
-        loadLocale('en', 'tests/fixtures/test-loader.mo', false);
-        assert(spy.calledWithExactly('en', expected, false));
+        loadLocale('en', 'tests/fixtures/test-loader.mo');
+        assert(spy.calledWithExactly('en', expected));
         rew.__ResetDependency__('addLocale');
     });
 
@@ -17,8 +17,8 @@ describe('loader', () => {
         const spy = sinon.spy();
         const expected = JSON.parse(fs.readFileSync('tests/fixtures/test-result-po.json'));
         rew.__Rewire__('addLocale', spy);
-        loadLocale('en', 'tests/fixtures/test-loader.po', false);
-        assert(spy.calledWithExactly('en', expected, false));
+        loadLocale('en', 'tests/fixtures/test-loader.po');
+        assert(spy.calledWithExactly('en', expected));
         rew.__ResetDependency__('addLocale');
     });
 
@@ -26,8 +26,8 @@ describe('loader', () => {
         const spy = sinon.spy();
         const expected = { headers: 'test', translations: 'test' };
         rew.__Rewire__('addLocale', spy);
-        loadLocale('en', { headers: 'test', translations: 'test' }, false);
-        assert(spy.calledWithExactly('en', expected, false));
+        loadLocale('en', { headers: 'test', translations: 'test' });
+        assert(spy.calledWithExactly('en', expected));
         rew.__ResetDependency__('addLocale');
     });
 });
@@ -38,7 +38,7 @@ describe('loader with transform', () => {
         const expected = JSON.parse(fs.readFileSync('tests/fixtures/test-result-po-before-transform.json'));
         rew.__Rewire__('addLocale', spy);
         loadLocale('en', 'tests/fixtures/test-loader-with-transform.po');
-        assert(spy.calledWithExactly('en', expected, true));
+        assert(spy.calledWithExactly('en', expected));
         rew.__ResetDependency__('addLocale');
     });
 });


### PR DESCRIPTION
These arguments seems to be omitted in e6efb62 and should be removed.

This is a small inconsistency I came across when I was tracing code. Should have no impact at any functions.