### PR TITLE
Use msgid for untranslated entries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,12 +30,18 @@ function isFuzzy(translationObj) {
         translationObj.comments.flag === 'fuzzy');
 }
 
+function hasTranslations(translationObj) {
+    if (!translationObj.msgstr) return false;
+
+    return translationObj.msgstr.reduce((r, trans) => r && trans.length, true);
+}
+
 function findTransObj(locale, str, ctx) {
     const locales = conf.getAvailLocales();
     const translations = locales[locale] && (
         locales[locale].translations[ctx] || locales[locale].translations['']);
     const translation = translations && translations[str];
-    if (translation && !isFuzzy(translation)) {
+    if (translation && !isFuzzy(translation) && hasTranslations(translation)) {
         return translation;
     }
     return null;

--- a/tests/fixtures/test-translations-resolve.po
+++ b/tests/fixtures/test-translations-resolve.po
@@ -32,3 +32,7 @@ msgstr ""
 "this is multiline\n"
 "demo for demonstrating\n"
 "multiline strings [translated]"
+
+#: test/fixtures/fixtures:13
+msgid "An untranslated entry"
+msgstr ""

--- a/tests/test_translations_resolve.js
+++ b/tests/test_translations_resolve.js
@@ -18,6 +18,11 @@ describe('translations resolve', () => {
         expect(result).to.not.contain('testtt');
         expect(result).to.eql('5 test');
     });
+
+    it('should use msgid when entry is not translated yet', () => {
+        const result = t`An untranslated entry`;
+        expect(result).to.eql('An untranslated entry');
+    });
 });
 
 


### PR DESCRIPTION
- Adjusts `findTransObj` so that it returns null for [untranslated entries](https://www.gnu.org/software/gettext/manual/html_node/Untranslated-Entries.html)
- Unit test for testing untranslated entries

Fixes #111 