### PR TITLE
chore(travis): Add explicit node versions 8, 10, latest LTS and latest stable release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 
 node_js:
   - 8
+  - 10
+  - lts/*
   - node
 
 before_script:


### PR DESCRIPTION
Update Travis to build against explicit versions of node:

* As the LTS and stable _may_ move on, we ensure that versions 8 and 10 are still covered.