### PR TITLE
'package.json' update: license, mocha config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "i18n"
   ],
   "scripts": {
-    "test": "BABEL_ENV=test mocha --compilers js:@babel/register tests",
-    "codecov-test": "BABEL_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha -- --compilers js:@babel/register tests",
+    "test": "BABEL_ENV=test mocha --require @babel/register tests",
+    "codecov-test": "BABEL_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha -- --require @babel/register tests",
     "lib:build": "babel src --out-dir dist && webpack && NODE_ENV=production webpack -p",
     "lint": "eslint ./src ./tests",
     "fix": "eslint --fix ./src ./tests",
@@ -27,7 +27,7 @@
     "url": "git+https://github.com/ttag-org/ttag.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/ttag-org/ttag.git/issues"
   },


### PR DESCRIPTION
Hi and thanks for the tool!

This PR addresses two minor things in the `package.json`:
1. `mocha` is configured with `--require` instead of `--compilers `, see [changelog](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#-1-deprecations) and [wiki](https://github.com/mochajs/mocha/wiki/compilers-deprecation).
1. License name - in fact it's [MIT](https://github.com/ttag-org/ttag/blob/master/LICENSE).