### PR TITLE
Allow exprs to contain the strings "$1" and "$2"

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,7 @@ const memoize1 = (f) => (arg) => {
     return mem[arg];
 };
 
-const reg = (i) => new RegExp(`\\$\\{([\\s]+?|\\s?)${i}([\\s]+?|\\s?)}`);
+const reg = (i) => new RegExp(`\\$\\{(?:[\\s]+?|\\s?)${i}(?:[\\s]+?|\\s?)}`);
 const memReg = memoize1(reg);
 
 export const msgid2Orig = (id, exprs) => {

--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import { assert, expect } from 'chai';
-import { getMsgid, transformTranslateObj, dedentStr,
-    transformCompactObj } from '../src/utils';
+import { getMsgid, msgid2Orig, transformTranslateObj, dedentStr, transformCompactObj } from '../src/utils';
 
 function getStrsExprs(strs, ...exprs) {
     return [strs, exprs];
@@ -21,6 +20,14 @@ describe('utils getMsgid', () => {
     });
 });
 
+describe('utils msgid2Orig', () => {
+    it('should work with exprs containing dollar signs', () => {
+        const a = '$1';
+        const [strs, exprs] = getStrsExprs`test ${a}`;
+        const id = getMsgid(strs, exprs);
+        expect(msgid2Orig(id, exprs)).to.be.eql('test $1');
+    });
+});
 
 describe('utils transformTranslateObj', () => {
     it('should transform translate object', () => {


### PR DESCRIPTION
We're having [an issue](https://github.com/metabase/metabase/issues/9530) in Metabase with translating strings that have dollar values in them. Curiously, it's only an issue if the amount started with a "1" or a "2".

The root cause was the behavior of `String​.prototype​.replace()`. When the first arg is a regexp, the second arg can [reference captured groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter). Since the relevant regex in ttag contained two capturing groups, `$1` and `$2` took on special meaning.

To fix that, I just changed them to non-capturing groups. This felt like the simplest solution, but there are two other options I considered:

1. We could escape the dollar signs in the replacement string (e.g. '$$1' rather than '$1').
2. [Pass a function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter) as the second argument to replace. This function should return the replacement string, but importantly the "$" replacement rules are not applied.

If we don't like the non-capturing group solution, I'd advocate for 2 over 1.