### PR TITLE
fix for buildStr function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -40,7 +40,8 @@ export const msgid2Orig = (id, exprs) => {
 };
 
 export const buildStr = (strs, exprs) => {
-    return strs.reduce((r, s, i) => r + s + (exprs[i] !== undefined ? exprs[i] : ''), '');
+    const exprsLength = exprs.length - 1;
+    return strs.reduce((r, s, i) => r + s + (i <= exprsLength ? exprs[i] : ''), '');
 };
 
 export const buildArr = (strs, exprs) => {

--- a/tests/test_translations_resolve.js
+++ b/tests/test_translations_resolve.js
@@ -168,3 +168,35 @@ describe('test compact format regression', () => {
         expect(result2).to.eql('Langue par défaut');
     });
 });
+
+describe('should use undefined for untranslated string', () => {
+    it('Should`t strip undefined variables value in main translation', () => {
+        const blank = undefined;
+        const index = {};
+        const key = 'demo';
+        const poData = {
+            headers: {
+                'content-type': 'text/plain; charset=utf-8',
+                'plural-forms': 'nplurals = 2; plural = (n > 1);',
+            },
+            translations: {
+                '': {
+                    'Demo: ${ blank } ${ process.version } ${ index[key] }': {
+                        msgid: 'Demo: ${ blank } ${ process.version } ${ index[key] }',
+                        msgstr: ['__Démo: ${ blank } ${ process.version } ${ index[key] }'],
+                    },
+                },
+            },
+        };
+        addLocale('fr', poData);
+        function demo() {
+            return t`Demo: ${blank} ${process.version} ${index[key]}`;
+        }
+        const untranslated = demo();
+        useLocale('fr');
+        const translated = demo();
+
+        expect(untranslated).to.eql('Demo: undefined v16.15.1 undefined');
+        expect(translated).to.eql('__Démo: undefined v16.15.1 undefined');
+    });
+});


### PR DESCRIPTION
In this PR I fix issue https://github.com/ttag-org/ttag/issues/262

```
import { addLocale, t, useLocale } from "ttag";

let blank: unknown;
const index: Record<string, unknown> = {};
const key = "demo";

addLocale("fr", {
	headers: {
		"content-type": "text/plain; charset=utf-8",
		"plural-forms": "nplurals = 2; plural = (n > 1);"
	},
	translations: {
		"": {
			"Demo: ${ blank } ${ process.version } ${ index[key] }": {
				msgid: "Demo: ${ blank } ${ process.version } ${ index[key] }",
				msgstr: ["Démo: ${ blank } ${ process.version } ${ index[key] }"]
			}
		}
	}
});

function demo() {
	console.log(t`Demo: ${blank} ${process.version} ${index[key]}`);
}
demo();
useLocale("fr");
demo();
```
Result before PR:

```
Demo:  v18.16.0 
Démo: undefined v18.16.0 undefined
```
Result current:
```
Demo: undefined v18.16.0 undefined
Démo: undefined v18.16.0 undefined
```

