### PR TITLE
fix for hermes engine on react native

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
         libraryTarget: 'umd',
         globalObject: 'this',
     },
+    devtool: false,
     module: {
         rules: [
             {


### PR DESCRIPTION
remove broken source mapping since it breaks dev builds on react native using hermes engine.

adress issue https://github.com/ttag-org/ttag/issues/278