### PR TITLE
Export types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "module": "./dist/ttag.esm.min.mjs",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/ttag.esm.min.mjs",
     "require": "./index.js"
   },


### PR DESCRIPTION
To properly resolve types (TS7016) the types should be exported under the `types` key